### PR TITLE
Made the algorithm to delete big businesses from results less complex

### DIFF
--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -22,12 +22,10 @@ import java.util.Iterator;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.EntityNotFoundException;
+
 /** BusinessesService object representing all businesses 
 * components of the webapp.
  **/
@@ -46,18 +44,11 @@ public class BusinessesService {
   public BusinessesService(List<Listing> allBusinesses) {
     this.allBusinesses = allBusinesses;
   }
-  private DatastoreService datastore;
-  public PreparedQuery getBigBusinessFromDatabase(){
-     datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query = new Query("BigBusinesses");
-    PreparedQuery queryOfDatabase = datastore.prepare(query);
-    return queryOfDatabase;
-  }
 
   public List<Listing> removeBigBusinessesFromResults(PreparedQuery queryOfDatabase){
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Iterator<Listing> businesses =  allBusinesses.iterator();
     String businessName;
-    Iterator<Entity> bigBusinessEntities = queryOfDatabase.asIterator();
     while (businesses.hasNext()) {
       Listing currentBusiness = businesses.next();
       try {

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -61,7 +61,11 @@ public class BusinessesService {
     while (businesses.hasNext()) {
       Listing currentBusiness = businesses.next();
       try {
-        businessName = (String) datastore.get(KeyFactory.createKey("BigBusinesses", currentBusiness.getName())).getProperty("Business");
+        businessName = 
+            (String) datastore.get(KeyFactory.createKey(
+                                    "BigBusinesses", 
+                                    currentBusiness.getName()))
+                              .getProperty("Business");
         if(businessName.equals(currentBusiness.getName())){
           businesses.remove();
         }

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -45,7 +45,7 @@ public class BusinessesService {
     this.allBusinesses = allBusinesses;
   }
 
-  public List<Listing> removeBigBusinessesFromResults(PreparedQuery queryOfDatabase){
+  public List<Listing> removeBigBusinessesFromResults(){
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Iterator<Listing> businesses =  allBusinesses.iterator();
     String businessName;

--- a/src/main/java/com/google/sps/data/SmallCityService.java
+++ b/src/main/java/com/google/sps/data/SmallCityService.java
@@ -66,7 +66,7 @@ public class SmallCityService {
   // To remove the big businesses from the list 
   // that will be returned from the use of the Places API 
   public void filterBySmallBusinesses() {
-    businesses = businessesService.removeBigBusinessesFromResults(queryOfDatabase);
+    businesses = businessesService.removeBigBusinessesFromResults();
   }
   
   // To be used for unit testing file to be able to get list 

--- a/src/main/java/com/google/sps/data/SmallCityService.java
+++ b/src/main/java/com/google/sps/data/SmallCityService.java
@@ -22,9 +22,6 @@ import java.util.Iterator;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
 
 /** SmallCityService object representing all components of the webapp **/
 public class SmallCityService {
@@ -34,7 +31,6 @@ public class SmallCityService {
   private BusinessesService businessesService;
   private List<Listing> businesses;
   private final static Logger LOGGER = Logger.getLogger(SmallCityService.class.getName());
-  private PreparedQuery queryOfDatabase;
 
   public SmallCityService() { }
   
@@ -70,7 +66,6 @@ public class SmallCityService {
   // To remove the big businesses from the list 
   // that will be returned from the use of the Places API 
   public void filterBySmallBusinesses() {
-    queryOfDatabase = businessesService.getBigBusinessFromDatabase();
     businesses = businessesService.removeBigBusinessesFromResults(queryOfDatabase);
   }
   

--- a/src/test/java/com/google/sps/BigBusinessesTest.java
+++ b/src/test/java/com/google/sps/BigBusinessesTest.java
@@ -41,6 +41,8 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
 import com.google.maps.model.Photo;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
 
 @RunWith(JUnit4.class)
 public final class BigBusinessesTest {
@@ -134,9 +136,11 @@ public final class BigBusinessesTest {
     String rating = "Rating";
     String photos = "Photos";
     datastore = DatastoreServiceFactory.getDatastoreService();
-    Entity businessEntity = new Entity("BigBusinesses");
+    Entity businessEntity;
+    Key key;
     for(Listing business: sampleDatabaseOfBigBusinesses) {
-      businessEntity = new Entity("BigBusinesses");
+      // key = KeyFactory.createKey("key",business.getName());
+      businessEntity = new Entity("BigBusinesses",business.getName());
       businessEntity.setProperty(title, business.getName());
       businessEntity.setProperty(address, business.getFormattedAddress());
       businessEntity.setProperty(rating, business.getRating());
@@ -144,6 +148,7 @@ public final class BigBusinessesTest {
       businessEntity.setProperty(businessTypes, Arrays.asList(
                                                     business.getBusinessTypes()));
       datastore.put(businessEntity);
+      System.out.println(businessEntity.getKey());
     }
   }
 

--- a/src/test/java/com/google/sps/BigBusinessesTest.java
+++ b/src/test/java/com/google/sps/BigBusinessesTest.java
@@ -139,7 +139,7 @@ public final class BigBusinessesTest {
     Entity businessEntity;
     Key key;
     for(Listing business: sampleDatabaseOfBigBusinesses) {
-      businessEntity = new Entity("BigBusinesses",business.getName());
+      businessEntity = new Entity("BigBusinesses", business.getName());
       businessEntity.setProperty(title, business.getName());
       businessEntity.setProperty(address, business.getFormattedAddress());
       businessEntity.setProperty(rating, business.getRating());

--- a/src/test/java/com/google/sps/BigBusinessesTest.java
+++ b/src/test/java/com/google/sps/BigBusinessesTest.java
@@ -139,7 +139,6 @@ public final class BigBusinessesTest {
     Entity businessEntity;
     Key key;
     for(Listing business: sampleDatabaseOfBigBusinesses) {
-      // key = KeyFactory.createKey("key",business.getName());
       businessEntity = new Entity("BigBusinesses",business.getName());
       businessEntity.setProperty(title, business.getName());
       businessEntity.setProperty(address, business.getFormattedAddress());
@@ -148,7 +147,6 @@ public final class BigBusinessesTest {
       businessEntity.setProperty(businessTypes, Arrays.asList(
                                                     business.getBusinessTypes()));
       datastore.put(businessEntity);
-      System.out.println(businessEntity.getKey());
     }
   }
 


### PR DESCRIPTION
Summary: I made the method that connects to the database less complex and made it so to delete a business that will be returned from the places API. Also, the method is now of O(n) complexity instead of O(n^2).

I deleted getBigBusinessFromDatabase, because to connect to the database I only need one line of code. Also, instead of a having a nested while loop to compare if the businesses from the results are the same as the big businesses in the database. I made it so each big business now in the database has a key, and I only need to use datastore.get method to access a big business based on its key with one loop and to delete it from the results if found. 