### PR TITLE
Make closer businesses that have the searched product appear

### DIFF
--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -90,7 +90,7 @@ public class BusinessesService {
       while (response.results.length < MAX_NUMBER_OF_RESULTS_PER_REQUEST && 
              radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
         // Increase radius if there are less than 20 results 
-        radius = INITIAL_RADIUS * RADIUS_MULTIPLIER;
+        radius *= RADIUS_MULTIPLIER;
         response = request.location(latLng).radius(radius).await();
       }
 

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -77,7 +77,7 @@ public class BusinessesService {
             .apiKey(KEY)
             .build();
     TextSearchRequest request = PlacesApi.textSearchQuery(context, product);
-    int radius = 500;
+    int radius = 1500;
 
     try {
       PlacesSearchResponse response = request.location(latLng)

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -52,6 +52,8 @@ public class BusinessesService {
   
   private final int ALLOWED_SEARCH_REQUESTS = 3;
   private final int MAX_ALLOWED_TEXT_SEARCH_RADIUS = 50000;
+  private final int RADIUS_MULTIPLIAR = 4;
+  private final int MAX_NUMBER_OF_RESULTS_PER_REQUEST = 20;
   private final int MIN_FOLLOWERS = 50000;
   private final int SMALL_BUSINESSES_DISPLAYED = 15;
   private final String START_SUBSTRING = "| ";
@@ -84,9 +86,9 @@ public class BusinessesService {
               .radius(radius)
               .await();
 
-      while (response.results.length < 20 && 
+      while (response.results.length < MAX_NUMBER_OF_RESULTS_PER_REQUEST && 
              radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
-        radius *= 4;
+        radius *= RADIUS_MULTIPLIAR;
         response = request.location(latLng).radius(radius).await();
       }
 

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -52,7 +52,7 @@ public class BusinessesService {
   
   private final int ALLOWED_SEARCH_REQUESTS = 3;
   private final int MAX_ALLOWED_TEXT_SEARCH_RADIUS = 50000;
-  private final int RADIUS_MULTIPLIAR = 4;
+  private final int RADIUS_MULTIPLIER = 4;
   private final int MAX_NUMBER_OF_RESULTS_PER_REQUEST = 20;
   private final int MIN_FOLLOWERS = 50000;
   private final int SMALL_BUSINESSES_DISPLAYED = 15;
@@ -90,7 +90,7 @@ public class BusinessesService {
              radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
         // If the list of businesses are not enough, the radius is increased
         // in hopes to get more results for that product search      
-        radius *= RADIUS_MULTIPLIAR;
+        radius *= RADIUS_MULTIPLIER;
         response = request.location(latLng).radius(radius).await();
       }
 

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -51,7 +51,7 @@ public class BusinessesService {
         Logger.getLogger(BusinessesService.class.getName());
   
   private final int ALLOWED_SEARCH_REQUESTS = 3;
-  private final int TEXT_SEARCH_RADIUS = 10000;
+  private final int MAX_ALLOWED_TEXT_SEARCH_RADIUS = 50000;
   private final int MIN_FOLLOWERS = 50000;
   private final int SMALL_BUSINESSES_DISPLAYED = 15;
   private final String START_SUBSTRING = "| ";
@@ -77,12 +77,19 @@ public class BusinessesService {
             .apiKey(KEY)
             .build();
     TextSearchRequest request = PlacesApi.textSearchQuery(context, product);
-    
+    int radius = 500;
+
     try {
       PlacesSearchResponse response = request.location(latLng)
-              .radius(TEXT_SEARCH_RADIUS)
+              .radius(radius)
               .await();
-      
+
+      while (response.results.length < 20 && 
+             radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
+        radius *= 4;
+        response = request.location(latLng).radius(radius).await();
+      }
+
       for (int i=0; i<ALLOWED_SEARCH_REQUESTS; i++) {
         for(PlacesSearchResult place : response.results) {
           String url = getUrlFromPlaceDetails(context, place.placeId);

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -88,6 +88,8 @@ public class BusinessesService {
 
       while (response.results.length < MAX_NUMBER_OF_RESULTS_PER_REQUEST && 
              radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
+        // If the list of businesses are not enough, the radius is increased
+        // in hopes to get more results for that product search      
         radius *= RADIUS_MULTIPLIAR;
         response = request.location(latLng).radius(radius).await();
       }

--- a/src/main/java/com/google/sps/data/BusinessesService.java
+++ b/src/main/java/com/google/sps/data/BusinessesService.java
@@ -52,6 +52,7 @@ public class BusinessesService {
   
   private final int ALLOWED_SEARCH_REQUESTS = 3;
   private final int MAX_ALLOWED_TEXT_SEARCH_RADIUS = 50000;
+  private final int INITIAL_RADIUS = 1500;
   private final int RADIUS_MULTIPLIER = 4;
   private final int MAX_NUMBER_OF_RESULTS_PER_REQUEST = 20;
   private final int MIN_FOLLOWERS = 50000;
@@ -79,7 +80,7 @@ public class BusinessesService {
             .apiKey(KEY)
             .build();
     TextSearchRequest request = PlacesApi.textSearchQuery(context, product);
-    int radius = 1500;
+    int radius = INITIAL_RADIUS;
 
     try {
       PlacesSearchResponse response = request.location(latLng)
@@ -88,9 +89,8 @@ public class BusinessesService {
 
       while (response.results.length < MAX_NUMBER_OF_RESULTS_PER_REQUEST && 
              radius < MAX_ALLOWED_TEXT_SEARCH_RADIUS) {
-        // If the list of businesses are not enough, the radius is increased
-        // in hopes to get more results for that product search      
-        radius *= RADIUS_MULTIPLIER;
+        // Increase radius if there are less than 20 results 
+        radius = INITIAL_RADIUS * RADIUS_MULTIPLIER;
         response = request.location(latLng).radius(radius).await();
       }
 


### PR DESCRIPTION
Summary: I made the radius smaller for the product search for the Text Search Request. Also, if enough results are not returned, another request is made, but with a bigger radius.

I changed the TEXT_SEARCH_RADIUS variable into the MAX_ALLOWED_TEXT_SEARCH_RADIUS variable which will be used to stop the changing radius if needed.

getBusinessesFromTextSearch() - Inside this method, I made a local radius variable and it is used for the product search using the text search request. However, if not enough results are returned using that radius, I will quadruple that radius and make another request using it. If needed this process will repeat until, either enough results are returned or that, radius is bigger then the MAX_ALLOWED_TEXT_SEARCH_RADIUS.
